### PR TITLE
Added clarity and fixed required packages command

### DIFF
--- a/build-instructions.md
+++ b/build-instructions.md
@@ -89,3 +89,6 @@ Refer to the insturctions here: https://wiki.gnome.org/GitLab
 1. Clean the whole repo with `git clean -dfx`
 2. Use the bootstrap commands but set VALAC to an older valac version e.g `valac-0.48`.
 3. You'll have a working version of the compiler in development again.
+
+### Having issues?
+Create an issue in this repository. We're only human after all :wink:.

--- a/build-instructions.md
+++ b/build-instructions.md
@@ -36,7 +36,11 @@ weasyprint
 ```
 ### 2. Setup git
 
-Follow the insturctions in the [Git section in the elementary OS developer documentation](https://docs.elementary.io/develop/writing-apps/the-basic-setup#git) then come back here.
+Follow the insturctions in the [Git section in the elementary OS developer documentation](https://docs.elementary.io/develop/writing-apps/the-basic-setup#git) then come back here (There's a step that tells you to add your SSH Key to GitHub. You don't need to follow those instructions).
+
+Now create an account on the [GNOME GitLab](https://gitlab.gnome.org/users/sign_in) then add your SSH Key there: https://gitlab.gnome.org/-/profile/keys
+
+Note: On the sign in screen you may see an option to pick between "GNOME account" and "Standard". Pick "Standard".
 
 ### 3. Clone the compiler repository project
 Run one of the following commands in a terminal.

--- a/build-instructions.md
+++ b/build-instructions.md
@@ -13,6 +13,7 @@ Note: These following instructions have only been tested on elementary OS 6 Odin
 First check for updates to packages:
 ```bash
 sudo apt update
+
 ```
 
 Now Install the required packages 

--- a/build-instructions.md
+++ b/build-instructions.md
@@ -26,12 +26,13 @@ flex \
 libbison-dev \
 libgraphviz-dev \
 make \
-autoconf
+autoconf \
 autoconf-archive \
 automake \
 libtool \
 help2man \
 weasyprint
+
 ```
 ### 2. Setup git
 

--- a/build-instructions.md
+++ b/build-instructions.md
@@ -48,17 +48,20 @@ Run one of the following commands in a terminal.
 Using HTTPS:
 ```bash
 git clone https://gitlab.gnome.org/GNOME/vala
+
 ```
 
 Using SSH (Recommended):
 ```bash
 git clone git@gitlab.gnome.org:GNOME/vala.git
+
 ```
 
 ### 4. Build Vala
 Install a prebuilt Vala Compiler. Why? Because Vala is used to build Vala:
 ```bash	
 sudo apt install valac
+
 ```
 
 Now run these commands in your terminal (This might take a while depending on how fast your machine is):
@@ -67,6 +70,7 @@ Now run these commands in your terminal (This might take a while depending on ho
 cd vala
 ./autogen.sh
 make && sudo make install
+
 ```
 
 ### 5. After building Vala


### PR DESCRIPTION
- Clarify that insturctions are for elementary OS 6.0 Odin
- Build instructions typo on 'autoconf' line. Missing '\'
- Add GitLab accunt instructions to 'Setup git' section
- Command formatting in repository cloning instructions
- Encourage users to create issues if they are having issues
